### PR TITLE
Update to .NET 10 / Aspire 13.4, modernize AI stack (MAF + MCP), refresh slides

### DIFF
--- a/.devcontainer/.net/devcontainer.json
+++ b/.devcontainer/.net/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": ".NET Aspire",
-  // Base .NET 9 image. Alternatively a Dockerfile/compose could be used.
-  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm",
+  // Base .NET 10 image. Alternatively a Dockerfile/compose could be used.
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:3": {},
     "ghcr.io/devcontainers/features/powershell:2": {},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build", // Name of your build task in tasks.json
-			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net9.0/BuildWithAspire.AppHost.dll",
+			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net10.0/BuildWithAspire.AppHost.dll",
 			"args": ["--environment", "Ollama"],
 			"cwd": "${workspaceFolder}/src/BuildWithAspire.AppHost",
 			"stopAtEntry": false,
@@ -23,7 +23,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build", // Name of your build task in tasks.json
-			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net9.0/BuildWithAspire.AppHost.dll",
+			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net10.0/BuildWithAspire.AppHost.dll",
 			"args": ["--environment", "GitHubModels"],
 			"cwd": "${workspaceFolder}/src/BuildWithAspire.AppHost",
 			"stopAtEntry": false,
@@ -34,7 +34,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build", // Name of your build task in tasks.json
-			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net9.0/BuildWithAspire.AppHost.dll",
+			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net10.0/BuildWithAspire.AppHost.dll",
 			"args": ["--environment", "FoundryLocal"],
 			"cwd": "${workspaceFolder}/src/BuildWithAspire.AppHost",
 			"stopAtEntry": false,
@@ -45,7 +45,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build", // Name of your build task in tasks.json
-			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net9.0/BuildWithAspire.AppHost.dll",
+			"program": "${workspaceFolder}/src/BuildWithAspire.AppHost/bin/Debug/net10.0/BuildWithAspire.AppHost.dll",
 			"args": ["--environment", "AzureOpenAI"],
 			"cwd": "${workspaceFolder}/src/BuildWithAspire.AppHost",
 			"stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Chat Agent                  WeatherTools
 
 ### Prerequisites
 
-- .NET 9.0 SDK or later
+- .NET 10.0 SDK or later
 - Docker Desktop (for Aspire)
 - Visual Studio Code or Visual Studio 2022
 

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "src/BuildWithAspire.AppHost/BuildWithAspire.AppHost.csproj"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="https://api.nuget.org/v3/index.json" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="https://api.nuget.org/v3/index.json">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/slides/Slides.md
+++ b/slides/Slides.md
@@ -192,7 +192,7 @@ footer: '@Chris_L_Ayers - https://chris-ayers.com'
 
 - **Databases**: PostgreSQL, MySQL, MongoDB, SQL Server
 - **Messaging**: Kafka, RabbitMQ, NATS
-- **AI & Observability**: Ollama, Semantic Kernel, OpenTelemetry
+- **AI & Observability**: Ollama, OpenAI, Foundry, OpenTelemetry
 
 </div>
 <div>
@@ -235,34 +235,34 @@ footer: '@Chris_L_Ayers - https://chris-ayers.com'
 ---
 
 
-# What's New in .NET Aspire 9.5
+# What's New in .NET Aspire 13.4
 
 <div class="columns">
 <div>
 
 ## ⚙️ CLI & Tooling
 
-- **aspire update** - Auto-update packages
-- **SSH Remote port forwarding** in VS Code
+- **TypeScript AppHost** now GA
+- **aspire deploy / publish** GA
+- **AI agent readiness** via skills
 
-## 🎨 Dashboard Enhancements
+## 🎨 Dashboard
 
-- **GenAI Visualizer** - Explore AI interactions
-- **Multi-resource console** logs view
+- **AI Agents dialog**
+- Structured search & trace filtering
 
 </div>
 <div>
 
-## 🤖 New Integrations
+## 🧩 App Model
 
-- **OpenAI hosting** integration
-- **GitHub Models** & **Azure AI Foundry** catalogs
-- **Dev Tunnels** hosting support
+- **Go** & **Bun** hosting integrations
+- **Blazor WebAssembly** hosting (preview)
 
 ## 🚀 Deployment
 
-- **Azure Container App Jobs**
-- **Built-in Azure deployment** via `aspire deploy`
+- **Azure Container App Jobs** stable
+- Richer **Kubernetes / AKS** APIs
 
 </div>
 </div>
@@ -324,7 +324,6 @@ aspire exec
 ```bash
 azd up         # Deploy everything
 azd deploy     # App only
-azd provision  # Infrastructure only
 azd init       # Initialize
 ```
 
@@ -336,9 +335,7 @@ azd init       # Initialize
 - Auto-detects app structure
 - Environment variable mapping
 - Native Aspire support
-- Credential providers
 - Key Vault integration
-- Secure access
 
 </div>
 </div>
@@ -368,8 +365,6 @@ var api = builder.AddProject<Projects.Api>("api")
 - **Automatic prompting** for missing parameters
 - **Rich form inputs** in dashboard
 - **Secret masking** for sensitive data
-- **Validation support** with custom rules
-- **Save to user secrets** for persistence
 
 **Input Types**: Text, Password, Choice, Boolean, Number
 
@@ -383,7 +378,7 @@ var api = builder.AddProject<Projects.Api>("api")
 | **Component** | **Local** | **Cloud** |
 |--------------|----------|----------|
 | **AI Models** | Ollama, Foundry local, LM Studio | Azure OpenAI, AI Foundry |
-| **Models** | Llama 3, Phi-4, Qwen | GPT-4.1, GPT-5-mini, Claude 4 |
+| **Models** | Llama 3.2, Qwen2.5, Phi-4 | GPT-5, GPT-5-mini, Claude 4 |
 | **Vector DB** | Qdrant, Chroma, pgvector | Azure AI Search, Cosmos DB |
 
 **Features**: Zero-friction transitions • Emulator support • Hybrid development • Auto configuration • Secret management
@@ -430,7 +425,6 @@ public class ExampleService(IChatClient chatClient)
 - **Privacy & Security**: All data stays on your machine
 - **Offline Capability**: Work without internet connectivity
 - **Fast Iteration**: No network latency for testing
-- **Model Experimentation**: Try different open-source models
 
 </div>
 </div>
@@ -461,11 +455,10 @@ public class ExampleService(IChatClient chatClient)
 </div>
 <div>
 
-- **Latest Models**: Access to GPT-4, Claude, and cutting-edge AI
+- **Latest Models**: Access to GPT-5, Claude 4, and cutting-edge AI
 - **Global Availability**: 99.9% SLA with worldwide deployment
 - **Managed Infrastructure**: No server maintenance required
 - **Advanced Features**: Function calling, vision, audio processing
-- **Compliance Ready**: SOC 2, HIPAA, and enterprise certifications
 
 </div>
 </div>
@@ -491,7 +484,6 @@ public class ExampleService(IChatClient chatClient)
 - **Inconsistent APIs**: Each framework had unique approaches
 - **Integration Complexity**: Difficult to combine tools
 - **Provider Lock-in**: Hard to switch AI providers
-- **Learning Curve**: Multiple frameworks to master
 
 </div>
 </div>
@@ -505,10 +497,9 @@ public class ExampleService(IChatClient chatClient)
 
 ## Unified Multi-Agent Platform
 
-- **Consolidation**: Replaces Semantic Kernel & AutoGen
-- **Built on Microsoft.Extensions.AI**: Leverages unified abstractions
-- **Multi-Agent Orchestration**: Coordinate multiple AI agents
-- **Event-Driven Architecture**: Flexible agent communication
+- **Now GA**: Unifies Semantic Kernel & AutoGen
+- **Built on Microsoft.Extensions.AI**: Unified abstractions
+- **Multi-Agent Orchestration**: Coordinate AI agents
 
 </div>
 <div>
@@ -516,11 +507,33 @@ public class ExampleService(IChatClient chatClient)
 ## Key Features
 
 - **Agent Types**: Task-based, conversational, autonomous
-- **Memory Systems**: Short-term and long-term context
-- **Tool Integration**: Function calling and external tools
+- **Tool Integration**: MCP tools & function calling
 - **Provider Agnostic**: Works with any AI backend
 
-**Learn more**: [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
+</div>
+</div>
+
+---
+
+# Model Context Protocol (MCP)
+
+<div class="columns">
+<div>
+
+## Standardized Tool Access
+
+- **Open protocol** for exposing tools to AI
+- **Dynamic discovery**: agents load tools at runtime
+- **Transport-agnostic**: stdio, HTTP, SSE
+
+</div>
+<div>
+
+## In this Demo
+
+- **MCP server** hosts Math, Weather, System & Text tools
+- **MAF agent** discovers tools via `McpClientTool`
+- **Local tool-calling** with Foundry Local (Qwen2.5)
 
 </div>
 </div>
@@ -547,19 +560,17 @@ public class ExampleService(IChatClient chatClient)
 ## Links
 
 - [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview)
-- [What's new in .NET Aspire 9.5](https://learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-aspire-9.5)
+- [What's new in .NET Aspire 13.4](https://aspire.dev/whats-new/aspire-13-4/)
 - [Microsoft.Extensions.AI](https://learn.microsoft.com/en-us/dotnet/ai/microsoft-extensions-ai)
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
-- [Aspirify](https://aspireify.net/)
 - [Aspire Samples](https://github.com/dotnet/aspire-samples)
-- [eShopLite](https://github.com/Azure-Samples/eShopLite)
 
 </div>
 <div>
 
 ## Follow Chris Ayers
 
-![w:400px](./img/chris_ayers.svg)
+![w:300px](./img/chris_ayers.svg)
 
 <!--
 <i class="fa-brands fa-bluesky"></i> BlueSky: [@chris-ayers.com](https://bsky.app/profile/chris-ayers.com)

--- a/src/BuildWithAspire.Abstractions/AIConfiguration.cs
+++ b/src/BuildWithAspire.Abstractions/AIConfiguration.cs
@@ -12,7 +12,16 @@ public static class AIConfiguration
         AzureAIFoundry
     }
 
-    public record AISettings(AIProvider Provider, string DeploymentName, string Model, int TimeoutSeconds);
+    public record AISettings(AIProvider Provider, string DeploymentName, string Model, int TimeoutSeconds)
+    {
+        /// <summary>
+        /// True when the model was set explicitly via <c>AI:Model</c> configuration,
+        /// as opposed to falling back to the provider default. The AppHost uses this to
+        /// choose between the strongly-typed model catalog (defaults) and the string
+        /// overloads (explicit overrides).
+        /// </summary>
+        public bool ModelExplicitlyConfigured { get; init; }
+    }
 
     public static AISettings GetSettings(IConfiguration configuration)
     {
@@ -21,7 +30,10 @@ public static class AIConfiguration
         var model = GetModel(configuration, provider);
         var timeoutSeconds = GetTimeoutSeconds(configuration);
 
-        return new AISettings(provider, deploymentName, model, timeoutSeconds);
+        return new AISettings(provider, deploymentName, model, timeoutSeconds)
+        {
+            ModelExplicitlyConfigured = !string.IsNullOrEmpty(configuration["AI:Model"])
+        };
     }
 
     public static AIProvider GetProvider(IConfiguration configuration)
@@ -61,13 +73,21 @@ public static class AIConfiguration
         var model = provider switch
         {
             AIProvider.Ollama => "llama3.2",
-            AIProvider.AzureOpenAI => "gpt-4o",
-            AIProvider.GitHubModels => "openai/gpt-4o-mini",
-            AIProvider.AzureAIFoundry => "phi-3.5-mini",
+            AIProvider.AzureOpenAI => "gpt-5",
+            AIProvider.GitHubModels => "openai/gpt-5-mini",
+            // Foundry Local runs small on-device models; cloud Azure AI Foundry defaults to a
+            // hosted OpenAI model. These names mirror the strongly-typed catalog constants the
+            // AppHost deploys (FoundryModel.Local.Qwen2515b / FoundryModel.OpenAI.Gpt5Mini) so the
+            // advertised AI:Model matches the deployed model. qwen2.5-1.5b reliably emits tool
+            // calls locally (the phi-4-mini Foundry build does not).
+            AIProvider.AzureAIFoundry => IsFoundryLocal(configuration) ? "qwen2.5-1.5b" : "gpt-5-mini",
             _ => throw new InvalidOperationException($"No default model available for provider: {provider}")
         };
         return model;
     }
+
+    private static bool IsFoundryLocal(IConfiguration configuration) =>
+        configuration["AI:Provider"]?.ToLowerInvariant() == "foundrylocal";
 
     public static int GetTimeoutSeconds(IConfiguration configuration)
     {

--- a/src/BuildWithAspire.Abstractions/BuildWithAspire.Abstractions.csproj
+++ b/src/BuildWithAspire.Abstractions/BuildWithAspire.Abstractions.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/src/BuildWithAspire.ApiService/BuildWithAspire.ApiService.csproj
+++ b/src/BuildWithAspire.ApiService/BuildWithAspire.ApiService.csproj
@@ -1,33 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>02f7f1fc-3cf9-47fd-bb88-3a9b566a5bbe</UserSecretsId>
+    <!-- Microsoft.AI.Foundry.Local (Core) ships native assets and requires a RuntimeIdentifier.
+         Default to the host RID so a plain `dotnet build`/`dotnet run` restores correctly on any OS. -->
+    <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.2-preview.1.25522.3" />
-    <PackageReference Include="Aspire.Azure.AI.Inference" Version="9.5.2-preview.1.25522.3" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.5.2" />
-    <PackageReference Include="CommunityToolkit.Aspire.OllamaSharp" Version="9.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
+    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="13.4.6-preview.1.26319.6" />
+    <PackageReference Include="Aspire.Azure.AI.Inference" Version="13.4.6-preview.1.26319.6" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.6" />
+    <PackageReference Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Pin transitive Microsoft.OpenApi to a patched version (fixes GHSA-v5pm-xwqc-g5wc) -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
+
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.10.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.7.0-preview.1.25356.2" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.10.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.1-preview.1.25521.4" />
-    <PackageReference Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.251016.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.9.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.AI.Foundry.Local" Version="1.2.3" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.13.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildWithAspire.ApiService/Endpoints/ChatEndpoints.cs
+++ b/src/BuildWithAspire.ApiService/Endpoints/ChatEndpoints.cs
@@ -16,31 +16,25 @@ public static class ChatEndpoints
         var group = routes.MapGroup("/conversations");
 
         group.MapGet("/", GetConversations)
-            .WithName("GetConversations")
-            .WithOpenApi();
+            .WithName("GetConversations");
 
         group.MapGet("/{id}", GetConversation)
-            .WithName("GetConversation")
-            .WithOpenApi();
+            .WithName("GetConversation");
 
         group.MapPost("/", CreateConversation)
-            .WithName("CreateConversation")
-            .WithOpenApi();
+            .WithName("CreateConversation");
 
         group.MapPost("/{id}/messages", SendMessage)
             .WithName("SendMessage")
-            .WithOpenApi()
             .RequireRateLimiting("chat");
 
         group.MapDelete("/{id}", DeleteConversation)
-            .WithName("DeleteConversation")
-            .WithOpenApi();
+            .WithName("DeleteConversation");
 
         // Legacy endpoint for backward compatibility
         routes.MapGet("/chat", async (ChatService chatService, string message) =>
                 await chatService.ProcessMessage(message).ConfigureAwait(false))
             .WithName("GetChat")
-            .WithOpenApi()
             .RequireRateLimiting("chat");
 
         return group;

--- a/src/BuildWithAspire.ApiService/Endpoints/McpEndpoints.cs
+++ b/src/BuildWithAspire.ApiService/Endpoints/McpEndpoints.cs
@@ -14,16 +14,13 @@ public static class McpEndpoints
 
         group.MapPost("/call/{toolName}", CallTool)
             .WithName("CallMcpTool")
-            .WithOpenApi()
             .RequireRateLimiting("weather");
 
         group.MapGet("/tools", ListTools)
-            .WithName("ListMcpTools")
-            .WithOpenApi();
+            .WithName("ListMcpTools");
 
         group.MapGet("/health", HealthCheck)
-            .WithName("McpHealthCheck")
-            .WithOpenApi();
+            .WithName("McpHealthCheck");
 
         return group;
     }

--- a/src/BuildWithAspire.ApiService/Endpoints/WeatherEndpoints.cs
+++ b/src/BuildWithAspire.ApiService/Endpoints/WeatherEndpoints.cs
@@ -14,7 +14,6 @@ public static class WeatherEndpoints
 
         group.MapGet("/", GetWeatherForecast)
             .WithName("GetWeatherForecast")
-            .WithOpenApi()
             .RequireRateLimiting("weather");
 
         return group;
@@ -28,11 +27,8 @@ public static class WeatherEndpoints
         var logger = loggerFactory.CreateLogger("WeatherForecast");
         var weatherAgent = new Microsoft.Agents.AI.ChatClientAgent(
             client,
-            new Microsoft.Agents.AI.ChatClientAgentOptions
-            {
-                Name = "WeatherAssistant",
-                Instructions = "You are a helpful assistant that provides a description of the weather in one word based on the temperature."
-            });
+            instructions: "You are a helpful assistant that provides a description of the weather in one word based on the temperature.",
+            name: "WeatherAssistant");
 
         return GetForecasts(weatherAgent, logger, settings);
     }

--- a/src/BuildWithAspire.ApiService/Extensions/AIServiceExtensions.cs
+++ b/src/BuildWithAspire.ApiService/Extensions/AIServiceExtensions.cs
@@ -34,15 +34,16 @@ public static class AIServiceExtensions
                 break;
 
             case AIConfiguration.AIProvider.AzureOpenAI:
-                builder.AddAzureOpenAIClient("ai-service")
-                    .AddChatClient(aiSettings.DeploymentName);
-                break;
-
-            case AIConfiguration.AIProvider.GitHubModels:
-                builder.AddOpenAIClient(aiSettings.DeploymentName)
+                builder.AddAzureOpenAIClient(aiSettings.DeploymentName)
                     .AddChatClient();
                 break;
 
+            // GitHub Models and Azure AI Foundry (local emulator + cloud) expose the
+            // Azure AI Inference / OpenAI-compatible chat completions protocol, so they
+            // use AddAzureChatCompletionsClient rather than the Azure OpenAI client
+            // (which targets the /openai/deployments/... URL scheme and 404s here).
+            // Matches the official Aspire FoundryEndToEnd / GitHubModelsEndToEnd playgrounds.
+            case AIConfiguration.AIProvider.GitHubModels:
             case AIConfiguration.AIProvider.AzureAIFoundry:
                 builder.AddAzureChatCompletionsClient(aiSettings.DeploymentName)
                     .AddChatClient();

--- a/src/BuildWithAspire.ApiService/Services/ChatService.cs
+++ b/src/BuildWithAspire.ApiService/Services/ChatService.cs
@@ -51,13 +51,13 @@ public class ChatService
             .Use((chatMessages, options, next, cancellationToken) =>
             {
                 // Inject tools into ChatOptions for every request
-                if (options.Tools?.Count is null or 0)
+                if (options is not null && options.Tools?.Count is null or 0)
                 {
                     options.Tools = _tools?.Select(t => (AITool)t).ToList();
                     _logger.LogInformation("Middleware: Injected {ToolCount} tools into ChatOptions", options.Tools?.Count ?? 0);
                 }
 
-                var toolCount = options.Tools?.Count ?? 0;
+                var toolCount = options?.Tools?.Count ?? 0;
                 _logger.LogInformation("Middleware: Sending request to model with {ToolCount} tools available", toolCount);
                 var result = next(chatMessages, options, cancellationToken);
                 _logger.LogInformation("Middleware: Received response from model");
@@ -69,16 +69,13 @@ public class ChatService
         // Create an AI Agent using the Microsoft Agent Framework with dynamic tools
         _agent = new ChatClientAgent(
             toolEnabledClient,
-            new ChatClientAgentOptions
-            {
-                Name = "ChatAssistant",
-                Instructions = @"You are an AI demonstration application.
+            instructions: @"You are an AI demonstration application.
                     You are a helpful chatbot with access to various tools dynamically discovered from the MCP server.
                     Use the available tools when appropriate to provide accurate information.
                     When a user asks for something that a tool can provide (like a random number, weather, calculations, etc.), USE THE TOOL instead of making up an answer.
                     Respond to the user's input responsibly.
-                    All responses should be safe for work."
-            });
+                    All responses should be safe for work.",
+            name: "ChatAssistant");
 
         _isInitialized = true;
         _logger.LogInformation("AI Agent initialized with {ToolCount} MCP tools available", _tools.Count());

--- a/src/BuildWithAspire.ApiService/Services/ChatService.cs
+++ b/src/BuildWithAspire.ApiService/Services/ChatService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using BuildWithAspire.Abstractions;
 using BuildWithAspire.ApiService.Models;
 using Microsoft.Extensions.AI;
@@ -5,7 +6,7 @@ using Microsoft.Agents.AI;
 
 namespace BuildWithAspire.ApiService.Services;
 
-public class ChatService
+public partial class ChatService
 {
     private AIAgent? _agent;
     private readonly IChatClient _chatClient;
@@ -42,43 +43,32 @@ public class ChatService
 
         _logger.LogInformation("Initializing AI Agent with dynamic MCP tools...");
 
-        // Dynamically load tools from MCP server
+        // Dynamically load tools from the MCP server. McpClientTool instances derive from
+        // AIFunction (and therefore AITool), so they can be handed straight to the agent.
         _tools = await _toolConverter.GetAllToolsAsync(cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation("Loaded {ToolCount} tools from MCP server", _tools.Count());
+        var tools = _tools.Cast<AITool>().ToList();
+        _logger.LogInformation("Loaded {ToolCount} tools from MCP server", tools.Count);
 
-        // Create a chat client with function invocation enabled and tools configured via middleware
-        var toolEnabledClient = _chatClient.AsBuilder()
-            .Use((chatMessages, options, next, cancellationToken) =>
-            {
-                // Inject tools into ChatOptions for every request
-                if (options is not null && options.Tools?.Count is null or 0)
-                {
-                    options.Tools = _tools?.Select(t => (AITool)t).ToList();
-                    _logger.LogInformation("Middleware: Injected {ToolCount} tools into ChatOptions", options.Tools?.Count ?? 0);
-                }
-
-                var toolCount = options?.Tools?.Count ?? 0;
-                _logger.LogInformation("Middleware: Sending request to model with {ToolCount} tools available", toolCount);
-                var result = next(chatMessages, options, cancellationToken);
-                _logger.LogInformation("Middleware: Received response from model");
-                return result;
-            })
-            .UseFunctionInvocation()
-            .Build();
-
-        // Create an AI Agent using the Microsoft Agent Framework with dynamic tools
+        // Create the agent using the Microsoft Agent Framework, supplying the MCP tools at
+        // construction time. ChatClientAgent automatically decorates the IChatClient with the
+        // function-invocation middleware (UseProvidedChatClientAsIs defaults to false), so we do
+        // not wire UseFunctionInvocation() or a custom tool-injection pipeline ourselves. This
+        // mirrors the official MAF agent pattern (see the aspire FoundryAgents playground).
         _agent = new ChatClientAgent(
-            toolEnabledClient,
-            instructions: @"You are an AI demonstration application.
-                    You are a helpful chatbot with access to various tools dynamically discovered from the MCP server.
-                    Use the available tools when appropriate to provide accurate information.
-                    When a user asks for something that a tool can provide (like a random number, weather, calculations, etc.), USE THE TOOL instead of making up an answer.
-                    Respond to the user's input responsibly.
-                    All responses should be safe for work.",
-            name: "ChatAssistant");
+            _chatClient,
+            instructions: """
+                You are an AI demonstration application.
+                You are a helpful chatbot with access to various tools dynamically discovered from the MCP server.
+                Use the available tools when appropriate to provide accurate information.
+                When a user asks for something that a tool can provide (like a random number, weather, calculations, etc.), USE THE TOOL instead of making up an answer.
+                Respond to the user's input responsibly.
+                All responses should be safe for work.
+                """,
+            name: "ChatAssistant",
+            tools: tools);
 
         _isInitialized = true;
-        _logger.LogInformation("AI Agent initialized with {ToolCount} MCP tools available", _tools.Count());
+        _logger.LogInformation("AI Agent initialized with {ToolCount} MCP tools available", tools.Count);
     }
 
     public async Task<string> ProcessMessage(string message)
@@ -101,7 +91,7 @@ public class ChatService
             var response = await _agent.RunAsync(message ?? string.Empty).ConfigureAwait(false);
             var duration = DateTime.UtcNow - startTime;
 
-            var combinedResponse = response.Text ?? string.Empty;
+            var combinedResponse = SanitizeResponse(response.Text);
 
             _logger.LogInformation("AI response generated successfully. ResponseLength: {ResponseLength}, Duration: {Duration}ms",
                 combinedResponse.Length, duration.TotalMilliseconds);
@@ -165,7 +155,7 @@ public class ChatService
             var response = await _agent.RunAsync(chatMessages, cancellationToken: cts.Token).ConfigureAwait(false);
             var duration = DateTime.UtcNow - startTime;
 
-            var combinedResponse = response.Text ?? string.Empty;
+            var combinedResponse = SanitizeResponse(response.Text);
 
             _logger.LogInformation("AI conversation response generated successfully. InputMessages: {InputMessages}, ResponseLength: {ResponseLength}, Duration: {Duration}ms",
                 messageCount, combinedResponse.Length, duration.TotalMilliseconds);
@@ -187,4 +177,34 @@ public class ChatService
             throw new InvalidOperationException($"Failed to process messages: {ex.Message}", ex);
         }
     }
+
+    /// <summary>
+    /// Removes tool-call template noise that some local models (e.g. the qwen2.5 / Hermes family
+    /// served through Foundry Local) echo into the text channel in addition to the structured
+    /// tool_calls the serving layer already parses. The tools still fire correctly; this only
+    /// cleans the visible answer. Model-agnostic and a no-op for models that emit clean text.
+    /// </summary>
+    public static string SanitizeResponse(string? text)    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var cleaned = ToolCallTemplateRegex().Replace(text, string.Empty);
+        cleaned = OrphanToolCallTagRegex().Replace(cleaned, string.Empty);
+        cleaned = ExcessBlankLinesRegex().Replace(cleaned, "\n\n");
+        return cleaned.Trim();
+    }
+
+    // Matches a complete <tool_call>...</tool_call> block (Singleline so '.' spans newlines).
+    [GeneratedRegex(@"<tool_call>.*?</tool_call>", RegexOptions.Singleline | RegexOptions.IgnoreCase)]
+    private static partial Regex ToolCallTemplateRegex();
+
+    // Defensively removes any orphaned opening/closing tool_call tags left by a truncated block.
+    [GeneratedRegex(@"</?tool_call>", RegexOptions.IgnoreCase)]
+    private static partial Regex OrphanToolCallTagRegex();
+
+    // Collapses the blank lines left behind after stripping a block.
+    [GeneratedRegex(@"\n{3,}")]
+    private static partial Regex ExcessBlankLinesRegex();
 }

--- a/src/BuildWithAspire.AppHost/BuildWithAspire.AppHost.csproj
+++ b/src/BuildWithAspire.AppHost/BuildWithAspire.AppHost.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
@@ -10,17 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="9.5.2" />
-    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="9.5.2" />
-    <PackageReference Include="Aspire.Hosting.Azure.AIFoundry" Version="9.5.2-preview.1.25522.3" />
-    <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="9.5.2" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.5.2" />
-    <PackageReference Include="Aspire.Hosting.GitHub.Models" Version="9.5.2-preview.1.25522.3" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.AIFoundry" Version="13.1.3-preview.1.26166.8" />
+    <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.GitHub.Models" Version="13.4.6" />
     <PackageReference Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="9.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
-    <PackageReference Include="System.Text.Json" Version="9.0.10" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildWithAspire.AppHost/BuildWithAspire.AppHost.csproj
+++ b/src/BuildWithAspire.AppHost/BuildWithAspire.AppHost.csproj
@@ -10,10 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.Azure" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure.AIFoundry" Version="13.1.3-preview.1.26166.8" />
+    <PackageReference Include="Aspire.Hosting.Foundry" Version="13.4.6-preview.1.26319.6" />
     <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.GitHub.Models" Version="13.4.6" />

--- a/src/BuildWithAspire.AppHost/Extensions/AIModelExtensions.cs
+++ b/src/BuildWithAspire.AppHost/Extensions/AIModelExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Aspire.Hosting;
+using Aspire.Hosting.Foundry;
+using Aspire.Hosting.GitHub;
 using BuildWithAspire.Abstractions;
 using AIProvider = BuildWithAspire.Abstractions.AIConfiguration.AIProvider;
 
@@ -61,7 +63,7 @@ public static class AIModelExtensions
         AIConfiguration.AISettings settings)
     {
         var config = builder.Configuration;
-        var modelVersion = config["AI:ModelVersion"] ?? "2024-11-20";
+        var modelVersion = config["AI:ModelVersion"] ?? "2025-08-07";
         var skuName = config["AI:SkuName"] ?? "GlobalStandard";
         var skuCapacity = config.GetValue<int?>("AI:SkuCapacity") ?? 150;
 
@@ -101,8 +103,13 @@ public static class AIModelExtensions
         IDistributedApplicationBuilder builder,
         AIConfiguration.AISettings settings)
     {
-        return builder.AddGitHubModel(settings.DeploymentName, settings.Model)
-                      .WithHealthCheck();
+        // Default to the strongly-typed model catalog; fall back to the string overload
+        // only when a model is explicitly configured via AI:Model.
+        var github = settings.ModelExplicitlyConfigured
+            ? builder.AddGitHubModel(settings.DeploymentName, settings.Model)
+            : builder.AddGitHubModel(settings.DeploymentName, GitHubModel.OpenAI.OpenAIGpt5Mini);
+
+        return github.WithHealthCheck();
     }
 
     private static IResourceBuilder<IResourceWithConnectionString> ConfigureAzureAIFoundry(
@@ -120,15 +127,25 @@ public static class AIModelExtensions
             $"Azure AI Foundry: {(isLocal ? "Local" : "Cloud")}, " +
             $"Model: {settings.Model}, Version: {version}");
 
-        var foundry = builder.AddAzureAIFoundry(name);
+        var foundry = builder.AddFoundry(name);
         if (isLocal)
         {
             foundry = foundry.RunAsFoundryLocal();
         }
 
-        return foundry
-            .AddDeployment(settings.DeploymentName, settings.Model, version, format)
-            .WithProperties(p => p.SkuCapacity = skuCapacity);
+        // Default to the strongly-typed model catalog (which encodes the correct model
+        // version/format per environment); fall back to the string overload only when a
+        // model is explicitly configured via AI:Model.
+        // Local default is qwen2.5-1.5b: unlike the Foundry-optimized phi-4-mini build (which
+        // does not emit tool calls), the qwen2.5 builds reliably invoke MCP tools. Swap to the
+        // larger FoundryModel.Local.Qwen257b (qwen2.5-7b) for higher tool-calling reliability.
+        var deployment = settings.ModelExplicitlyConfigured
+            ? foundry.AddDeployment(settings.DeploymentName, settings.Model, version, format)
+            : foundry.AddDeployment(
+                settings.DeploymentName,
+                isLocal ? FoundryModel.Local.Qwen2515b : FoundryModel.OpenAI.Gpt5Mini);
+
+        return deployment.WithProperties(p => p.SkuCapacity = skuCapacity);
     }
 
     private static IResourceBuilder<ProjectResource> ConnectToAIService(

--- a/src/BuildWithAspire.AppHost/appsettings.AzureAIFoundry.json
+++ b/src/BuildWithAspire.AppHost/appsettings.AzureAIFoundry.json
@@ -8,9 +8,9 @@
   "AI": {
     "Provider": "azureaifoundry",
     "DeploymentName": "chat",
-    "Model": "phi-3.5-mini",
-    "ModelVersion": "1",
-    "ModelFormat": "Microsoft",
+    "Model": "gpt-5-mini",
+    "ModelVersion": "2025-08-07",
+    "ModelFormat": "OpenAI",
     "SkuCapacity": 20
   }
 }

--- a/src/BuildWithAspire.AppHost/appsettings.AzureOpenAI.json
+++ b/src/BuildWithAspire.AppHost/appsettings.AzureOpenAI.json
@@ -8,8 +8,8 @@
   "AI": {
     "Provider": "azureopenai",
     "DeploymentName": "chat",
-    "Model": "gpt-4o",
-    "ModelVersion": "2024-11-20",
+    "Model": "gpt-5",
+    "ModelVersion": "2025-08-07",
     "SkuName": "GlobalStandard",
     "SkuCapacity": 10
   }

--- a/src/BuildWithAspire.AppHost/appsettings.FoundryLocal.json
+++ b/src/BuildWithAspire.AppHost/appsettings.FoundryLocal.json
@@ -9,8 +9,8 @@
   "AI": {
     "Provider": "foundrylocal",
     "DeploymentName": "chat",
-    "Model": "phi-3.5-mini",
-    "ModelVersion": "1",
+    "Model": "qwen2.5-1.5b",
+    "ModelVersion": "4",
     "ModelFormat": "Microsoft",
     "SkuCapacity": 20
   }

--- a/src/BuildWithAspire.AppHost/appsettings.GitHubModels.json
+++ b/src/BuildWithAspire.AppHost/appsettings.GitHubModels.json
@@ -9,6 +9,6 @@
   "AI": {
     "Provider": "githubmodels",
     "DeploymentName": "chat",
-    "Model": "openai/gpt-4.1-mini"
+    "Model": "openai/gpt-5-mini"
   }
 }

--- a/src/BuildWithAspire.MCPServer/BuildWithAspire.MCPServer.csproj
+++ b/src/BuildWithAspire.MCPServer/BuildWithAspire.MCPServer.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <!-- Pin transitive Microsoft.OpenApi to a patched version (fixes GHSA-v5pm-xwqc-g5wc) -->

--- a/src/BuildWithAspire.MCPServer/BuildWithAspire.MCPServer.csproj
+++ b/src/BuildWithAspire.MCPServer/BuildWithAspire.MCPServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RollForward>Major</RollForward>
   <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
@@ -24,13 +24,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.10.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.9.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Pin transitive Microsoft.OpenApi to a patched version (fixes GHSA-v5pm-xwqc-g5wc) -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildWithAspire.MCPServer/Program.cs
+++ b/src/BuildWithAspire.MCPServer/Program.cs
@@ -49,7 +49,8 @@ builder.Services.AddMcpServer(options =>
 })
 .WithTools<WeatherTools>()
 .WithTools<SystemTools>()
-.WithTools<MathTools>();
+.WithTools<MathTools>()
+.WithTools<TextTools>();
 
 // Add logging
 builder.Logging.AddConsole(options =>
@@ -100,28 +101,33 @@ app.MapGet("/debug/info", () =>
 })
 .WithName("DebugInfo");
 
-// Add diagnostic endpoint to list registered tools (for debugging)
-app.MapGet("/debug/tools", () =>
+// Add diagnostic endpoint to list registered tools (for debugging). Tool metadata is
+// enumerated directly from the DI-registered McpServerTool instances, so this endpoint
+// stays accurate automatically as tools are added or removed.
+app.MapGet("/debug/tools", (IEnumerable<McpServerTool> registeredTools) =>
 {
-    // This is a diagnostic endpoint to show the actual registered tool names
-    var tools = new[]
-    {
-        "getWeatherForecast",
-        "getCurrentWeather",
-        "convertTemperature",
-        "getCurrentDateTime",
-        "getSystemInfo",
-        "generateRandomNumber",
-        "encodeToBase64",
-        "decodeFromBase64",
-        "calculate",
-        "squareRoot",
-        "power",
-        "generateFibonacci",
-        "isPrime"
-    };
+    var tools = registeredTools
+        .Select(t => new
+        {
+            name = t.ProtocolTool.Name,
+            title = t.ProtocolTool.Title,
+            description = t.ProtocolTool.Description,
+            annotations = t.ProtocolTool.Annotations is { } a
+                ? new
+                {
+                    readOnly = a.ReadOnlyHint,
+                    idempotent = a.IdempotentHint,
+                    destructive = a.DestructiveHint,
+                    openWorld = a.OpenWorldHint
+                }
+                : null
+        })
+        .OrderBy(t => t.name, StringComparer.Ordinal)
+        .ToArray();
+
     return Results.Ok(new {
         message = "MCP tools registered with camelCase names (following official SDK conventions)",
+        count = tools.Length,
         tools = tools,
         usage = new
         {
@@ -154,7 +160,7 @@ app.Logger.LogInformation("Endpoints:");
 app.Logger.LogInformation("  - POST /   : JSON-RPC requests (auto-creates session on first request)");
 app.Logger.LogInformation("  - GET /    : SSE notifications stream");
 app.Logger.LogInformation("  - DELETE / : Session cleanup");
-app.Logger.LogInformation("Tools: Weather, System, Math");
+app.Logger.LogInformation("Tools: Weather, System, Math, Text");
 app.Logger.LogInformation("Session Timeout: 2 hours idle");
 
 // Run the MCP-compliant server

--- a/src/BuildWithAspire.MCPServer/Program.cs
+++ b/src/BuildWithAspire.MCPServer/Program.cs
@@ -73,8 +73,7 @@ app.MapGet("/health", () =>
         sessionSupport = "Yes - via Mcp-Session-Id header"
     });
 })
-.WithName("HealthCheck")
-.WithOpenApi();
+.WithName("HealthCheck");
 
 // Add diagnostic endpoint to show session and transport information
 app.MapGet("/debug/info", () =>
@@ -99,8 +98,7 @@ app.MapGet("/debug/info", () =>
         note = "Session IDs are managed automatically by the SDK's StatefulSessionManager"
     });
 })
-.WithName("DebugInfo")
-.WithOpenApi();
+.WithName("DebugInfo");
 
 // Add diagnostic endpoint to list registered tools (for debugging)
 app.MapGet("/debug/tools", () =>
@@ -134,8 +132,7 @@ app.MapGet("/debug/tools", () =>
         }
     });
 })
-.WithName("DebugTools")
-.WithOpenApi();
+.WithName("DebugTools");
 
 // Add OpenAPI for development
 if (app.Environment.IsDevelopment())

--- a/src/BuildWithAspire.MCPServer/Tools/MathTools.cs
+++ b/src/BuildWithAspire.MCPServer/Tools/MathTools.cs
@@ -18,7 +18,7 @@ public sealed class MathTools
         _logger = logger;
     }
 
-    [McpServerTool(Name = "calculate")]
+    [McpServerTool(Name = "calculate", Title = "Basic Calculator", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Performs basic arithmetic operations (add, subtract, multiply, divide).")]
     public CalculationResult Calculate(
         [Description("First number")] double a,
@@ -56,7 +56,7 @@ public sealed class MathTools
         }
     }
 
-    [McpServerTool(Name = "squareRoot")]
+    [McpServerTool(Name = "squareRoot", Title = "Square Root", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Calculates the square root of a number.")]
     public CalculationResult SquareRoot(
         [Description("Number to find square root of")] double number)
@@ -81,7 +81,7 @@ public sealed class MathTools
         );
     }
 
-    [McpServerTool(Name = "power")]
+    [McpServerTool(Name = "power", Title = "Exponentiation", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Raises a number to a specified power.")]
     public CalculationResult Power(
         [Description("Base number")] double baseNumber,
@@ -109,7 +109,7 @@ public sealed class MathTools
         }
     }
 
-    [McpServerTool(Name = "generateFibonacci")]
+    [McpServerTool(Name = "generateFibonacci", Title = "Fibonacci Sequence", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Generates the Fibonacci sequence up to n terms.")]
     public FibonacciResult GenerateFibonacci(
         [Description("Number of terms to generate (1-50)")] int terms)
@@ -153,7 +153,7 @@ public sealed class MathTools
         );
     }
 
-    [McpServerTool(Name = "isPrime")]
+    [McpServerTool(Name = "isPrime", Title = "Primality Test", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Checks if a number is prime.")]
     public PrimeCheckResult IsPrime(
         [Description("Number to check for primality")] long number)

--- a/src/BuildWithAspire.MCPServer/Tools/SystemTools.cs
+++ b/src/BuildWithAspire.MCPServer/Tools/SystemTools.cs
@@ -20,7 +20,7 @@ public sealed class SystemTools
         _logger = logger;
     }
 
-    [McpServerTool(Name = "getCurrentDateTime")]
+    [McpServerTool(Name = "getCurrentDateTime", Title = "Current Date and Time", ReadOnly = true, Idempotent = false, OpenWorld = false)]
     [Description("Gets the current date and time information.")]
     public DateTimeInfo GetCurrentDateTime()
     {
@@ -36,7 +36,7 @@ public sealed class SystemTools
         );
     }
 
-    [McpServerTool(Name = "getSystemInfo")]
+    [McpServerTool(Name = "getSystemInfo", Title = "System Information", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Gets basic system information including OS and .NET version.")]
     public SystemInfo GetSystemInfo()
     {
@@ -50,7 +50,7 @@ public sealed class SystemTools
         );
     }
 
-    [McpServerTool(Name = "generateRandomNumber")]
+    [McpServerTool(Name = "generateRandomNumber", Title = "Random Number Generator", ReadOnly = true, Idempotent = false, OpenWorld = false)]
     [Description("Generates a random number within the specified range.")]
     public RandomNumber GenerateRandomNumber(
         [Description("Minimum value (inclusive)")] int min = 1,
@@ -66,7 +66,7 @@ public sealed class SystemTools
         return new RandomNumber(value, min, max - 1);
     }
 
-    [McpServerTool(Name = "encodeToBase64")]
+    [McpServerTool(Name = "encodeToBase64", Title = "Base64 Encode", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Encodes text to Base64 format.")]
     public EncodingResult EncodeToBase64(
         [Description("Text to encode")] string text)
@@ -89,7 +89,7 @@ public sealed class SystemTools
         }
     }
 
-    [McpServerTool(Name = "decodeFromBase64")]
+    [McpServerTool(Name = "decodeFromBase64", Title = "Base64 Decode", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Decodes Base64 text to plain text.")]
     public EncodingResult DecodeFromBase64(
         [Description("Base64 text to decode")] string base64Text)

--- a/src/BuildWithAspire.MCPServer/Tools/TextTools.cs
+++ b/src/BuildWithAspire.MCPServer/Tools/TextTools.cs
@@ -1,0 +1,128 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace BuildWithAspire.MCPServer.Tools;
+
+/// <summary>
+/// Text manipulation and analysis tools for MCP clients.
+/// All operations are deterministic, read-only, and side-effect free, which makes
+/// them ideal for demonstrating tool-calling with small local models.
+/// </summary>
+[McpServerToolType]
+public sealed class TextTools
+{
+    private static readonly char[] SentenceTerminators = ['.', '!', '?'];
+
+    private readonly ILogger<TextTools> _logger;
+
+    public TextTools(ILogger<TextTools> logger)
+    {
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "countText", Title = "Text Statistics", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description("Counts the number of characters, words, lines, and sentences in the supplied text.")]
+    public TextStatistics CountText(
+        [Description("The text to analyze")] string text)
+    {
+        _logger.LogInformation("MCP Tool 'countText' called with text length={Length}", text?.Length ?? 0);
+
+        if (string.IsNullOrEmpty(text))
+        {
+            return new TextStatistics(0, 0, 0, 0, 0);
+        }
+
+        var characters = text.Length;
+        var charactersNoWhitespace = text.Count(c => !char.IsWhiteSpace(c));
+        var words = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+        var lines = text.Split('\n').Length;
+        var sentences = text.Split(SentenceTerminators, StringSplitOptions.RemoveEmptyEntries)
+            .Count(s => !string.IsNullOrWhiteSpace(s));
+
+        return new TextStatistics(characters, charactersNoWhitespace, words, lines, sentences);
+    }
+
+    [McpServerTool(Name = "transformCase", Title = "Transform Text Case", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description("Transforms text casing. Supported modes: 'upper', 'lower', 'title', 'reverse'.")]
+    public TextTransformResult TransformCase(
+        [Description("The text to transform")] string text,
+        [Description("Transform mode: 'upper', 'lower', 'title', or 'reverse'")] string mode = "upper")
+    {
+        _logger.LogInformation("MCP Tool 'transformCase' called with mode={Mode}", mode);
+
+        text ??= string.Empty;
+        var normalizedMode = mode?.Trim().ToLowerInvariant() ?? "upper";
+
+        switch (normalizedMode)
+        {
+            case "upper":
+                return new TextTransformResult(text.ToUpperInvariant(), normalizedMode, true, "Converted to upper case");
+            case "lower":
+                return new TextTransformResult(text.ToLowerInvariant(), normalizedMode, true, "Converted to lower case");
+            case "title":
+                var title = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(text.ToLowerInvariant());
+                return new TextTransformResult(title, normalizedMode, true, "Converted to title case");
+            case "reverse":
+                var reversed = new string(text.Reverse().ToArray());
+                return new TextTransformResult(reversed, normalizedMode, true, "Reversed the text");
+            default:
+                return new TextTransformResult(text, normalizedMode, false, $"Unknown mode: {mode}. Use 'upper', 'lower', 'title', or 'reverse'.");
+        }
+    }
+
+    [McpServerTool(Name = "slugify", Title = "URL Slug Generator", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description("Converts text into a URL-friendly slug (lowercase, hyphen-separated, alphanumeric).")]
+    public SlugResult Slugify(
+        [Description("The text to convert into a slug")] string text)
+    {
+        _logger.LogInformation("MCP Tool 'slugify' called with text length={Length}", text?.Length ?? 0);
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new SlugResult(string.Empty, "Empty input provided");
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var previousWasHyphen = false;
+
+        foreach (var ch in text.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+                previousWasHyphen = false;
+            }
+            else if (!previousWasHyphen)
+            {
+                builder.Append('-');
+                previousWasHyphen = true;
+            }
+        }
+
+        var slug = builder.ToString().Trim('-');
+        return new SlugResult(slug, $"Generated slug from {text.Length} characters");
+    }
+}
+
+public record TextStatistics(
+    int Characters,
+    int CharactersNoWhitespace,
+    int Words,
+    int Lines,
+    int Sentences
+);
+
+public record TextTransformResult(
+    string Result,
+    string Mode,
+    bool Success,
+    string Message
+);
+
+public record SlugResult(
+    string Slug,
+    string Message
+);

--- a/src/BuildWithAspire.MCPServer/Tools/WeatherTools.cs
+++ b/src/BuildWithAspire.MCPServer/Tools/WeatherTools.cs
@@ -21,7 +21,7 @@ public sealed class WeatherTools
         _chatClient = chatClient;
     }
 
-    [McpServerTool(Name = "getWeatherForecast")]
+    [McpServerTool(Name = "getWeatherForecast", Title = "Weather Forecast", ReadOnly = true, Idempotent = false, OpenWorld = false)]
     [Description("Gets a weather forecast for the next 5 days with AI-generated weather descriptions.")]
     public async Task<WeatherForecast[]> GetWeatherForecast(
         [Description("Maximum number of forecast days to return (1-10)")] int maxDays = 5)
@@ -54,7 +54,7 @@ public sealed class WeatherTools
         return forecasts.ToArray();
     }
 
-    [McpServerTool(Name = "getCurrentWeather")]
+    [McpServerTool(Name = "getCurrentWeather", Title = "Current Weather", ReadOnly = true, Idempotent = false, OpenWorld = false)]
     [Description("Gets current weather information for today with AI-generated description.")]
     public async Task<WeatherForecast> GetCurrentWeather()
     {
@@ -70,7 +70,7 @@ public sealed class WeatherTools
         );
     }
 
-    [McpServerTool(Name = "convertTemperature")]
+    [McpServerTool(Name = "convertTemperature", Title = "Temperature Converter", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Converts temperature between Celsius and Fahrenheit.")]
     public static TemperatureConversion ConvertTemperature(
         [Description("Temperature value to convert")] double temperature,

--- a/src/BuildWithAspire.ServiceDefaults/BuildWithAspire.ServiceDefaults.csproj
+++ b/src/BuildWithAspire.ServiceDefaults/BuildWithAspire.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildWithAspire.Web/BuildWithAspire.Web.csproj
+++ b/src/BuildWithAspire.Web/BuildWithAspire.Web.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.5.2-preview.1.25522.3" />
-    <PackageReference Include="Markdig" Version="0.43.0" />
+    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="13.4.6-preview.1.26319.6" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.7.0-preview.1.25356.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BuildWithAspire.ApiService.UnitTests/BuildWithAspire.ApiService.UnitTests.csproj
+++ b/tests/BuildWithAspire.ApiService.UnitTests/BuildWithAspire.ApiService.UnitTests.csproj
@@ -1,31 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <!-- Transitively references ApiService which pulls in Microsoft.AI.Foundry.Local (native, RID-required). -->
+    <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.10.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/BuildWithAspire.ApiService.UnitTests/Configuration/AIConfigurationExtendedTests.cs
+++ b/tests/BuildWithAspire.ApiService.UnitTests/Configuration/AIConfigurationExtendedTests.cs
@@ -40,10 +40,10 @@ public class AIConfigurationExtendedTests
     }
 
     [Theory]
-    [InlineData(AIConfiguration.AIProvider.AzureOpenAI, "gpt-4o")]
+    [InlineData(AIConfiguration.AIProvider.AzureOpenAI, "gpt-5")]
     [InlineData(AIConfiguration.AIProvider.Ollama, "llama3.2")]
-    [InlineData(AIConfiguration.AIProvider.GitHubModels, "openai/gpt-4o-mini")]
-    [InlineData(AIConfiguration.AIProvider.AzureAIFoundry, "phi-3.5-mini")]
+    [InlineData(AIConfiguration.AIProvider.GitHubModels, "openai/gpt-5-mini")]
+    [InlineData(AIConfiguration.AIProvider.AzureAIFoundry, "gpt-5-mini")]
     public void GetModel_WithProviders_ShouldReturnCorrectDefaults(AIConfiguration.AIProvider provider, string expectedModel)
     {
         // Arrange
@@ -51,6 +51,26 @@ public class AIConfigurationExtendedTests
 
         // Act
         var model = AIConfiguration.GetModel(configuration, provider);
+
+        // Assert
+        Assert.Equal(expectedModel, model);
+    }
+
+    [Theory]
+    [InlineData("foundrylocal", "qwen2.5-1.5b")]
+    [InlineData("azureaifoundry", "gpt-5-mini")]
+    public void GetModel_AzureAIFoundry_ShouldReturnEnvironmentSpecificDefault(string providerString, string expectedModel)
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AI:Provider"] = providerString
+            })
+            .Build();
+
+        // Act
+        var model = AIConfiguration.GetModel(configuration, AIConfiguration.AIProvider.AzureAIFoundry);
 
         // Assert
         Assert.Equal(expectedModel, model);

--- a/tests/BuildWithAspire.ApiService.UnitTests/Extensions/AIConfigurationTests.cs
+++ b/tests/BuildWithAspire.ApiService.UnitTests/Extensions/AIConfigurationTests.cs
@@ -64,9 +64,9 @@ public class AIConfigurationTests
 
     [Theory]
     [InlineData(AIConfiguration.AIProvider.Ollama, "llama3.2")]
-    [InlineData(AIConfiguration.AIProvider.AzureOpenAI, "gpt-4o")]
-    [InlineData(AIConfiguration.AIProvider.GitHubModels, "openai/gpt-4o-mini")]
-    [InlineData(AIConfiguration.AIProvider.AzureAIFoundry, "phi-3.5-mini")]
+    [InlineData(AIConfiguration.AIProvider.AzureOpenAI, "gpt-5")]
+    [InlineData(AIConfiguration.AIProvider.GitHubModels, "openai/gpt-5-mini")]
+    [InlineData(AIConfiguration.AIProvider.AzureAIFoundry, "gpt-5-mini")]
     public void GetModel_WithDefaultConfiguration_ReturnsProviderDefaults(AIConfiguration.AIProvider provider, string expectedModel)
     {
         // Arrange

--- a/tests/BuildWithAspire.ApiService.UnitTests/Services/ChatServiceSanitizeTests.cs
+++ b/tests/BuildWithAspire.ApiService.UnitTests/Services/ChatServiceSanitizeTests.cs
@@ -1,0 +1,60 @@
+using BuildWithAspire.ApiService.Services;
+
+namespace BuildWithAspire.ApiService.UnitTests.Services;
+
+public class ChatServiceSanitizeTests
+{
+    [Fact]
+    public void SanitizeResponse_StripsToolCallTemplate_KeepsAnswer()
+    {
+        // qwen2.5 / Hermes-style local models echo the tool-call template into the text channel
+        // in addition to the structured tool_calls the serving layer already parsed.
+        var raw = "<tool_call>\n{\"name\": \"squareRoot\", \"arguments\": {\"number\": 1764}}\n</tool_call>\nThe square root of 1764 is 42.";
+
+        var cleaned = ChatService.SanitizeResponse(raw);
+
+        Assert.Equal("The square root of 1764 is 42.", cleaned);
+        Assert.DoesNotContain("tool_call", cleaned, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SanitizeResponse_StripsMultipleToolCallBlocks()
+    {
+        var raw = "<tool_call>{\"name\":\"a\"}</tool_call>Line one.\n<tool_call>{\"name\":\"b\"}</tool_call>\nLine two.";
+
+        var cleaned = ChatService.SanitizeResponse(raw);
+
+        Assert.DoesNotContain("tool_call", cleaned, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Line one.", cleaned);
+        Assert.Contains("Line two.", cleaned);
+    }
+
+    [Fact]
+    public void SanitizeResponse_RemovesOrphanedToolCallTag()
+    {
+        var raw = "Partial answer.\n<tool_call>\n{\"name\": \"weather\"}";
+
+        var cleaned = ChatService.SanitizeResponse(raw);
+
+        Assert.DoesNotContain("<tool_call>", cleaned, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith("Partial answer.", cleaned);
+    }
+
+    [Fact]
+    public void SanitizeResponse_LeavesCleanTextUnchanged()
+    {
+        var raw = "The weather in Seattle is 55F and cloudy.";
+
+        var cleaned = ChatService.SanitizeResponse(raw);
+
+        Assert.Equal(raw, cleaned);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SanitizeResponse_HandlesNullOrEmpty(string? input)
+    {
+        Assert.Equal(string.Empty, ChatService.SanitizeResponse(input));
+    }
+}

--- a/tests/BuildWithAspire.ApiService.UnitTests/Services/ChatServiceTests.cs
+++ b/tests/BuildWithAspire.ApiService.UnitTests/Services/ChatServiceTests.cs
@@ -107,7 +107,7 @@ public class ChatServiceTests
         var model = AIConfiguration.GetModel(configuration, AIConfiguration.AIProvider.AzureOpenAI);
 
         // Assert
-        Assert.Equal("gpt-4o", model);
+        Assert.Equal("gpt-5", model);
     }
 
     [Fact]

--- a/tests/BuildWithAspire.AppHost.UnitTests/BuildWithAspire.AppHost.UnitTests.csproj
+++ b/tests/BuildWithAspire.AppHost.UnitTests/BuildWithAspire.AppHost.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="9.5.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/BuildWithAspire.AppHost.UnitTests/Extensions/AIModelExtensionsSimpleTests.cs
+++ b/tests/BuildWithAspire.AppHost.UnitTests/Extensions/AIModelExtensionsSimpleTests.cs
@@ -89,9 +89,9 @@ public class AIModelExtensionsSimpleTests
 
         // Act & Assert - Test each provider's default model
     Assert.Equal("llama3.2", GetAIModelFromConfiguration(configuration, AIProvider.Ollama));
-    Assert.Equal("gpt-4o", GetAIModelFromConfiguration(configuration, AIProvider.AzureOpenAI));
-    Assert.Equal("openai/gpt-4o-mini", GetAIModelFromConfiguration(configuration, AIProvider.GitHubModels));
-    Assert.Equal("phi-3.5-mini", GetAIModelFromConfiguration(configuration, AIProvider.AzureAIFoundry));
+    Assert.Equal("gpt-5", GetAIModelFromConfiguration(configuration, AIProvider.AzureOpenAI));
+    Assert.Equal("openai/gpt-5-mini", GetAIModelFromConfiguration(configuration, AIProvider.GitHubModels));
+    Assert.Equal("gpt-5-mini", GetAIModelFromConfiguration(configuration, AIProvider.AzureAIFoundry));
     }
 
     [Fact]
@@ -119,22 +119,9 @@ public class AIModelExtensionsSimpleTests
 
     private static string GetAIModelFromConfiguration(IConfiguration configuration, AIProvider provider)
     {
-        // Simulate what AIConfiguration.GetSettings does but forcing a provider for test determinism
-        var model = configuration["AI:Model"]; // If user overrides model we honor it
-        if (!string.IsNullOrWhiteSpace(model))
-        {
-            return provider == AIProvider.GitHubModels && !model.Contains('/')
-                ? $"openai/{model}" // normalization mirrors central logic
-                : model;
-        }
-
-        return provider switch
-        {
-            AIProvider.Ollama => "llama3.2",
-            AIProvider.AzureOpenAI => "gpt-4o",
-            AIProvider.GitHubModels => "openai/gpt-4o-mini",
-            AIProvider.AzureAIFoundry => "phi-3.5-mini",
-            _ => throw new InvalidOperationException($"No default model available for provider: {provider}")
-        };
+        // Delegate to the central resolution logic so this test stays in sync with
+        // AIConfiguration.GetModel (override handling, GitHub normalization, and the
+        // Foundry Local vs cloud default all live there).
+        return AIConfiguration.GetModel(configuration, provider);
     }
 }

--- a/tests/BuildWithAspire.Web.UnitTests/BuildWithAspire.Web.UnitTests.csproj
+++ b/tests/BuildWithAspire.Web.UnitTests/BuildWithAspire.Web.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,21 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="AngleSharp" Version="1.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
-    <PackageReference Include="bunit" Version="1.40.0" />
-    <PackageReference Include="bunit.web" Version="1.40.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="bunit" Version="2.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Overview

Modernizes the demo to the latest **.NET 10 / Aspire 13.4.6** stack, overhauls the AI provider routing and tooling to use the **Microsoft Agent Framework (MAF)** + **Model Context Protocol (MCP)**, and refreshes the slide deck with current information.

## Changes

**Platform & packages**
- Update to **.NET 10** and latest package versions.
- Migrate `Aspire.Hosting.Azure.AIFoundry` → **`Aspire.Hosting.Foundry`** (13.4.6-preview) and drop the redundant `Aspire.Hosting.AppHost` package.
- Add `aspire.config.json` (AppHost pointer for `aspire run`) and pin `nuget.org` via `nuget.config` with package source mapping.

**AI provider routing & models**
- Fix routing between **Ollama, GitHub, Foundry, and Azure OpenAI**.
- Upgrade the model catalog — cloud defaults **gpt-5 / gpt-5-mini**, Foundry Local default **qwen2.5-1.5b** (tool-capable).

**MAF + MCP**
- Align `ChatService` with the MAF `ChatClientAgent` pattern (tools passed at construction) and strip the qwen/Hermes `<tool_call>` template leak from responses.
- Add **`TextTools`** and modernize MCP server tool registration; `/debug/tools` now enumerates DI-registered `McpServerTool` instances.

**Slides**
- Refresh `slides/Slides.md`: Aspire **13.4** what's-new, **GPT-5 / Qwen2.5** models, **MAF GA**, and a new **Model Context Protocol** slide.
- Validate every slide renders within the 1280×720 frame (bare Marp template, measured `scrollHeight` vs `clientHeight`) — **0 overflowing slides**.

## Validation

- Build clean (0 warnings / 0 errors), **137 tests pass**.
- qwen2.5-1.5b local tool-calling verified clean end-to-end.
- All 41 rendered slide sections fit the frame.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>